### PR TITLE
Group to Org Authorization Mapping for release v6.5.1

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -6,6 +6,11 @@ clone:
     pull: true
 
 pipeline:
+  test:
+    image: golang:1.13.1
+    commands:
+      - make test-go
+
   publish_quay:
     image: plugins/docker
     secrets: [docker_username, docker_password]

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,30 @@
+---
+clone:
+  git:
+    # https://discourse.drone.io/t/planned-change-to-git-clone-logic/1165
+    image: plugins/git:next
+    pull: true
+
+pipeline:
+  publish_quay:
+    image: plugins/docker
+    secrets: [docker_username, docker_password]
+    registry: quay.io
+    repo: quay.io/mongodb/grafana
+    tags:
+      - git-${DRONE_COMMIT_SHA:0:7}
+    when:
+      event: push
+
+  publish_quay_release:
+    image: plugins/docker
+    secrets: [docker_username, docker_password]
+    registry: quay.io
+    repo: quay.io/mongodb/grafana
+    tags:
+      - git-${DRONE_COMMIT_SHA:0:7}
+      - ${DRONE_TAG}
+    when:
+      branch:
+        include: [release/*]
+      event: tag

--- a/.drone.yml
+++ b/.drone.yml
@@ -30,6 +30,4 @@ pipeline:
       - git-${DRONE_COMMIT_SHA:0:7}
       - ${DRONE_TAG}
     when:
-      branch:
-        include: [release/*]
       event: tag

--- a/pkg/api/login_oauth.go
+++ b/pkg/api/login_oauth.go
@@ -195,7 +195,7 @@ func (hs *HTTPServer) OAuthLogin(ctx *m.ReqContext) {
 	for _, group := range userInfo.Groups {
 		if orgs, ok := orgToRoleMap[group]; ok {
 			for _, org := range orgs {
-        // OrgID is optional in the toml configuration.
+				// OrgID is optional in the toml configuration.
 				if org.OrgID == 0 {
 					org.OrgID = 1
 				}

--- a/pkg/api/login_oauth.go
+++ b/pkg/api/login_oauth.go
@@ -195,6 +195,7 @@ func (hs *HTTPServer) OAuthLogin(ctx *m.ReqContext) {
 	for _, group := range userInfo.Groups {
 		if orgs, ok := orgToRoleMap[group]; ok {
 			for _, org := range orgs {
+        // OrgID is optional in the toml configuration.
 				if org.OrgID == 0 {
 					org.OrgID = 1
 				}

--- a/pkg/api/login_oauth.go
+++ b/pkg/api/login_oauth.go
@@ -190,6 +190,23 @@ func (hs *HTTPServer) OAuthLogin(ctx *m.ReqContext) {
 		}
 	}
 
+	orgToRoleMap := connect.OrgToRoleMap()
+
+	for _, group := range userInfo.Groups {
+		if orgs, ok := orgToRoleMap[group]; ok {
+			for _, org := range orgs {
+				if org.OrgID == 0 {
+					org.OrgID = 1
+				}
+				extUser.OrgRoles[org.OrgID] = m.RoleType(org.Role)
+
+				if org.GrafanaAdmin != nil && *org.GrafanaAdmin == true {
+					extUser.IsGrafanaAdmin = org.GrafanaAdmin
+				}
+			}
+		}
+	}
+
 	// add/update user in grafana
 	cmd := &m.UpsertUserCommand{
 		ReqContext:    ctx,

--- a/pkg/login/social/generic_oauth.go
+++ b/pkg/login/social/generic_oauth.go
@@ -224,7 +224,6 @@ func (s *SocialGenericOAuth) UserInfo(client *http.Client, token *oauth2.Token) 
 	var err error
 
 	if !s.extractToken(&data, token) || s.apiUrl != "" {
-		s.log.Debug("Fetching UserInfo ", s.apiUrl, token)
 		rawUserInfoResponse, err = HttpGet(client, s.apiUrl)
 		if err != nil {
 			return nil, fmt.Errorf("Error getting user info: %s", err)

--- a/pkg/login/social/generic_oauth.go
+++ b/pkg/login/social/generic_oauth.go
@@ -10,7 +10,7 @@ import (
 	"regexp"
 
 	"github.com/grafana/grafana/pkg/models"
-	"github.com/jmespath/go-jmespath"
+	jmespath "github.com/jmespath/go-jmespath"
 	"golang.org/x/oauth2"
 )
 
@@ -23,6 +23,7 @@ type SocialGenericOAuth struct {
 	emailAttributeName   string
 	emailAttributePath   string
 	roleAttributePath    string
+	orgToGroupRoleMap    map[string][]SocialGroup
 	teamIds              []int
 }
 
@@ -57,6 +58,10 @@ func (s *SocialGenericOAuth) IsTeamMember(client *http.Client) bool {
 	}
 
 	return false
+}
+
+func (s *SocialGenericOAuth) OrgToRoleMap() map[string][]SocialGroup {
+	return s.orgToGroupRoleMap
 }
 
 func (s *SocialGenericOAuth) IsOrganizationMember(client *http.Client) bool {
@@ -209,6 +214,7 @@ type UserInfoJson struct {
 	Username    string              `json:"username"`
 	Email       string              `json:"email"`
 	Upn         string              `json:"upn"`
+	Groups      []string            `json:"groups"`
 	Attributes  map[string][]string `json:"attributes"`
 }
 
@@ -217,7 +223,8 @@ func (s *SocialGenericOAuth) UserInfo(client *http.Client, token *oauth2.Token) 
 	var rawUserInfoResponse HttpGetResponse
 	var err error
 
-	if !s.extractToken(&data, token) {
+	if !s.extractToken(&data, token) || s.apiUrl != "" {
+		s.log.Debug("Fetching UserInfo ", s.apiUrl, token)
 		rawUserInfoResponse, err = HttpGet(client, s.apiUrl)
 		if err != nil {
 			return nil, fmt.Errorf("Error getting user info: %s", err)
@@ -241,13 +248,15 @@ func (s *SocialGenericOAuth) UserInfo(client *http.Client, token *oauth2.Token) 
 
 	role := s.extractRole(&data, rawUserInfoResponse.Body)
 
+	s.log.Debug("Getting role", role, rawUserInfoResponse.Body)
 	login := s.extractLogin(&data, email)
 
 	userInfo := &BasicUserInfo{
-		Name:  name,
-		Login: login,
-		Email: email,
-		Role:  role,
+		Name:   name,
+		Login:  login,
+		Email:  email,
+		Role:   role,
+		Groups: data.Groups,
 	}
 
 	if !s.IsTeamMember(client) {

--- a/pkg/login/social/generic_oauth.go
+++ b/pkg/login/social/generic_oauth.go
@@ -247,7 +247,6 @@ func (s *SocialGenericOAuth) UserInfo(client *http.Client, token *oauth2.Token) 
 
 	role := s.extractRole(&data, rawUserInfoResponse.Body)
 
-	s.log.Debug("Getting role", role, rawUserInfoResponse.Body)
 	login := s.extractLogin(&data, email)
 
 	userInfo := &BasicUserInfo{

--- a/pkg/login/social/github_oauth.go
+++ b/pkg/login/social/github_oauth.go
@@ -48,6 +48,7 @@ func (s *SocialGithub) IsSignupAllowed() bool {
 }
 
 func (s *SocialGithub) OrgToRoleMap() map[string][]SocialGroup {
+  // OrgToRoleMap not implemented in this provider
 	var emptyMap map[string][]SocialGroup
 	return emptyMap
 }

--- a/pkg/login/social/github_oauth.go
+++ b/pkg/login/social/github_oauth.go
@@ -48,7 +48,8 @@ func (s *SocialGithub) IsSignupAllowed() bool {
 }
 
 func (s *SocialGithub) OrgToRoleMap() map[string][]SocialGroup {
-  return nil
+	var emptyMap map[string][]SocialGroup
+	return emptyMap
 }
 
 func (s *SocialGithub) IsTeamMember(client *http.Client) bool {

--- a/pkg/login/social/github_oauth.go
+++ b/pkg/login/social/github_oauth.go
@@ -49,8 +49,7 @@ func (s *SocialGithub) IsSignupAllowed() bool {
 
 func (s *SocialGithub) OrgToRoleMap() map[string][]SocialGroup {
   // OrgToRoleMap not implemented in this provider
-	var emptyMap map[string][]SocialGroup
-	return emptyMap
+  return nil
 }
 
 func (s *SocialGithub) IsTeamMember(client *http.Client) bool {

--- a/pkg/login/social/github_oauth.go
+++ b/pkg/login/social/github_oauth.go
@@ -47,6 +47,10 @@ func (s *SocialGithub) IsSignupAllowed() bool {
 	return s.allowSignup
 }
 
+func (s *SocialGithub) OrgToRoleMap() map[string][]SocialGroup {
+  return nil
+}
+
 func (s *SocialGithub) IsTeamMember(client *http.Client) bool {
 	if len(s.teamIds) == 0 {
 		return true

--- a/pkg/login/social/gitlab_oauth.go
+++ b/pkg/login/social/gitlab_oauth.go
@@ -51,6 +51,11 @@ func (s *SocialGitlab) IsGroupMember(groups []string) bool {
 	return false
 }
 
+func (s *SocialGitlab) OrgToRoleMap() map[string][]SocialGroup {
+  return nil
+}
+
+
 func (s *SocialGitlab) GetGroups(client *http.Client) []string {
 	groups := make([]string, 0)
 

--- a/pkg/login/social/gitlab_oauth.go
+++ b/pkg/login/social/gitlab_oauth.go
@@ -53,8 +53,7 @@ func (s *SocialGitlab) IsGroupMember(groups []string) bool {
 
 func (s *SocialGitlab) OrgToRoleMap() map[string][]SocialGroup {
 	// OrgToRoleMap not implemented in this provider
-	var emptyMap map[string][]SocialGroup
-	return emptyMap
+  return nil
 }
 
 func (s *SocialGitlab) GetGroups(client *http.Client) []string {

--- a/pkg/login/social/gitlab_oauth.go
+++ b/pkg/login/social/gitlab_oauth.go
@@ -52,9 +52,9 @@ func (s *SocialGitlab) IsGroupMember(groups []string) bool {
 }
 
 func (s *SocialGitlab) OrgToRoleMap() map[string][]SocialGroup {
-  return nil
+	var emptyMap map[string][]SocialGroup
+	return emptyMap
 }
-
 
 func (s *SocialGitlab) GetGroups(client *http.Client) []string {
 	groups := make([]string, 0)

--- a/pkg/login/social/gitlab_oauth.go
+++ b/pkg/login/social/gitlab_oauth.go
@@ -52,6 +52,7 @@ func (s *SocialGitlab) IsGroupMember(groups []string) bool {
 }
 
 func (s *SocialGitlab) OrgToRoleMap() map[string][]SocialGroup {
+	// OrgToRoleMap not implemented in this provider
 	var emptyMap map[string][]SocialGroup
 	return emptyMap
 }

--- a/pkg/login/social/google_oauth.go
+++ b/pkg/login/social/google_oauth.go
@@ -32,8 +32,7 @@ func (s *SocialGoogle) IsSignupAllowed() bool {
 
 func (s *SocialGoogle) OrgToRoleMap() map[string][]SocialGroup {
 	// OrgToRoleMap not implemented in this provider
-	var emptyMap map[string][]SocialGroup
-	return emptyMap
+  return nil
 }
 
 func (s *SocialGoogle) UserInfo(client *http.Client, token *oauth2.Token) (*BasicUserInfo, error) {

--- a/pkg/login/social/google_oauth.go
+++ b/pkg/login/social/google_oauth.go
@@ -30,6 +30,10 @@ func (s *SocialGoogle) IsSignupAllowed() bool {
 	return s.allowSignup
 }
 
+func (s *SocialGoogle) OrgToRoleMap() map[string][]SocialGroup {
+	return nil
+}
+
 func (s *SocialGoogle) UserInfo(client *http.Client, token *oauth2.Token) (*BasicUserInfo, error) {
 	var data struct {
 		Id    string `json:"id"`

--- a/pkg/login/social/google_oauth.go
+++ b/pkg/login/social/google_oauth.go
@@ -31,7 +31,8 @@ func (s *SocialGoogle) IsSignupAllowed() bool {
 }
 
 func (s *SocialGoogle) OrgToRoleMap() map[string][]SocialGroup {
-	return nil
+	var emptyMap map[string][]SocialGroup
+	return emptyMap
 }
 
 func (s *SocialGoogle) UserInfo(client *http.Client, token *oauth2.Token) (*BasicUserInfo, error) {

--- a/pkg/login/social/google_oauth.go
+++ b/pkg/login/social/google_oauth.go
@@ -31,6 +31,7 @@ func (s *SocialGoogle) IsSignupAllowed() bool {
 }
 
 func (s *SocialGoogle) OrgToRoleMap() map[string][]SocialGroup {
+	// OrgToRoleMap not implemented in this provider
 	var emptyMap map[string][]SocialGroup
 	return emptyMap
 }

--- a/pkg/login/social/grafana_com_oauth.go
+++ b/pkg/login/social/grafana_com_oauth.go
@@ -50,6 +50,7 @@ func (s *SocialGrafanaCom) IsOrganizationMember(organizations []OrgRecord) bool 
 }
 
 func (s *SocialGrafanaCom) OrgToRoleMap() map[string][]SocialGroup {
+	// OrgToRoleMap not implemented in this provider
 	var emptyMap map[string][]SocialGroup
 	return emptyMap
 }

--- a/pkg/login/social/grafana_com_oauth.go
+++ b/pkg/login/social/grafana_com_oauth.go
@@ -49,6 +49,10 @@ func (s *SocialGrafanaCom) IsOrganizationMember(organizations []OrgRecord) bool 
 	return false
 }
 
+func (s *SocialGrafanaCom) OrgToRoleMap() map[string][]SocialGroup {
+	return nil
+}
+
 func (s *SocialGrafanaCom) UserInfo(client *http.Client, token *oauth2.Token) (*BasicUserInfo, error) {
 	var data struct {
 		Id    int         `json:"id"`

--- a/pkg/login/social/grafana_com_oauth.go
+++ b/pkg/login/social/grafana_com_oauth.go
@@ -51,8 +51,7 @@ func (s *SocialGrafanaCom) IsOrganizationMember(organizations []OrgRecord) bool 
 
 func (s *SocialGrafanaCom) OrgToRoleMap() map[string][]SocialGroup {
 	// OrgToRoleMap not implemented in this provider
-	var emptyMap map[string][]SocialGroup
-	return emptyMap
+	return nil
 }
 
 func (s *SocialGrafanaCom) UserInfo(client *http.Client, token *oauth2.Token) (*BasicUserInfo, error) {

--- a/pkg/login/social/grafana_com_oauth.go
+++ b/pkg/login/social/grafana_com_oauth.go
@@ -50,7 +50,8 @@ func (s *SocialGrafanaCom) IsOrganizationMember(organizations []OrgRecord) bool 
 }
 
 func (s *SocialGrafanaCom) OrgToRoleMap() map[string][]SocialGroup {
-	return nil
+	var emptyMap map[string][]SocialGroup
+	return emptyMap
 }
 
 func (s *SocialGrafanaCom) UserInfo(client *http.Client, token *oauth2.Token) (*BasicUserInfo, error) {

--- a/pkg/login/social/social.go
+++ b/pkg/login/social/social.go
@@ -234,10 +234,8 @@ func createOrganizationMapping(authConfig *auth.AuthConfig) map[string][]SocialG
 				GrafanaAdmin: group.IsGrafanaAdmin,
 			}
 			orgMap[group.GroupDN] = append(orgMap[group.GroupDN], s)
-
 		}
 	}
-
 	return orgMap
 }
 

--- a/pkg/login/social/social.go
+++ b/pkg/login/social/social.go
@@ -225,8 +225,7 @@ func NewOAuthService() {
 func createOrganizationMapping(authConfig *auth.AuthConfig) map[string][]SocialGroup {
 	var orgMap = make(map[string][]SocialGroup)
 	for _, auth := range authConfig.AuthMappings {
-		groups := auth.Groups
-		for _, group := range groups {
+		for _, group := range auth.Groups {
 
 			s := SocialGroup{
 				Role:         group.OrgRole,

--- a/pkg/login/social/social.go
+++ b/pkg/login/social/social.go
@@ -168,27 +168,14 @@ func NewOAuthService() {
 				allowSignup:    info.AllowSignup,
 			}
 		}
-
-		var orgMap = make(map[string][]SocialGroup)
+		var orgMap map[string][]SocialGroup
 		if info.ConfigFile != "" {
 			authConfig, err := auth.GetConfig(info.ConfigFile)
 			if err != nil {
 				logger.Info("Error", "err", err)
 			}
-			for _, auth := range authConfig.AuthMappings {
-				groups := auth.Groups
-				for _, group := range groups {
-					logger.Debug("Group: ", "group", group)
 
-					s := SocialGroup{
-						Role:         group.OrgRole,
-						OrgID:        group.OrgID,
-						GrafanaAdmin: group.IsGrafanaAdmin,
-					}
-					orgMap[group.GroupDN] = append(orgMap[group.GroupDN], s)
-
-				}
-			}
+			orgMap = createOrganizationMapping(authConfig)
 		}
 
 		// Generic - Uses the same scheme as Github.
@@ -233,6 +220,25 @@ func NewOAuthService() {
 			}
 		}
 	}
+}
+
+func createOrganizationMapping(authConfig *auth.AuthConfig) map[string][]SocialGroup {
+	var orgMap = make(map[string][]SocialGroup)
+	for _, auth := range authConfig.AuthMappings {
+		groups := auth.Groups
+		for _, group := range groups {
+
+			s := SocialGroup{
+				Role:         group.OrgRole,
+				OrgID:        group.OrgID,
+				GrafanaAdmin: group.IsGrafanaAdmin,
+			}
+			orgMap[group.GroupDN] = append(orgMap[group.GroupDN], s)
+
+		}
+	}
+
+	return orgMap
 }
 
 // GetOAuthProviders returns available oauth providers and if they're enabled or not

--- a/pkg/login/social/social.go
+++ b/pkg/login/social/social.go
@@ -9,6 +9,7 @@ import (
 	"golang.org/x/oauth2"
 
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/auth"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
 )
@@ -23,6 +24,12 @@ type BasicUserInfo struct {
 	Groups  []string
 }
 
+type SocialGroup struct {
+	Role         string
+	OrgID        int64
+	GrafanaAdmin *bool
+}
+
 type SocialConnector interface {
 	Type() int
 	UserInfo(client *http.Client, token *oauth2.Token) (*BasicUserInfo, error)
@@ -33,6 +40,7 @@ type SocialConnector interface {
 	Exchange(ctx context.Context, code string, authOptions ...oauth2.AuthCodeOption) (*oauth2.Token, error)
 	Client(ctx context.Context, t *oauth2.Token) *http.Client
 	TokenSource(ctx context.Context, t *oauth2.Token) oauth2.TokenSource
+	OrgToRoleMap() map[string][]SocialGroup
 }
 
 type SocialBase struct {
@@ -84,6 +92,7 @@ func NewOAuthService() {
 			TlsClientCa:                  sec.Key("tls_client_ca").String(),
 			TlsSkipVerify:                sec.Key("tls_skip_verify_insecure").MustBool(),
 			SendClientCredentialsViaPost: sec.Key("send_client_credentials_via_post").MustBool(),
+			ConfigFile:                   sec.Key("config_file").String(),
 		}
 
 		if !info.Enabled {
@@ -114,6 +123,8 @@ func NewOAuthService() {
 		}
 
 		logger := log.New("oauth." + name)
+
+		logger.Debug("Scopes", config.Scopes)
 
 		// GitHub.
 		if name == "github" {
@@ -158,6 +169,28 @@ func NewOAuthService() {
 			}
 		}
 
+		var orgMap = make(map[string][]SocialGroup)
+		if info.ConfigFile != "" {
+			authConfig, err := auth.GetConfig(info.ConfigFile)
+			if err != nil {
+				logger.Info("Error", "err", err)
+			}
+			for _, auth := range authConfig.AuthMappings {
+				groups := auth.Groups
+				for _, group := range groups {
+					logger.Debug("Group: ", "group", group)
+
+					s := SocialGroup{
+						Role:         group.OrgRole,
+						OrgID:        group.OrgID,
+						GrafanaAdmin: group.IsGrafanaAdmin,
+					}
+					orgMap[group.GroupDN] = append(orgMap[group.GroupDN], s)
+
+				}
+			}
+		}
+
 		// Generic - Uses the same scheme as Github.
 		if name == "generic_oauth" {
 			SocialMap["generic_oauth"] = &SocialGenericOAuth{
@@ -173,6 +206,7 @@ func NewOAuthService() {
 				roleAttributePath:    info.RoleAttributePath,
 				teamIds:              sec.Key("team_ids").Ints(","),
 				allowedOrganizations: util.SplitString(sec.Key("allowed_organizations").String()),
+				orgToGroupRoleMap:    orgMap,
 			}
 		}
 

--- a/pkg/login/social/social_test.go
+++ b/pkg/login/social/social_test.go
@@ -1,0 +1,58 @@
+package social
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/grafana/grafana/pkg/services/auth"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func newTrue() *bool {
+	b := true
+	return &b
+}
+
+func TestCreateOrganizationMapping(t *testing.T) {
+	Convey("Given a static mapping create a SocialGroup array", t, func() {
+
+		authConfig := auth.AuthConfig{
+			AuthMappings: []*auth.AuthOrgConfig{
+				&auth.AuthOrgConfig{
+					Groups: []*auth.GroupToOrgRole{
+						&auth.GroupToOrgRole{
+							GroupDN: "dn-my-group",
+							OrgID:   1,
+							OrgRole: "Viewer",
+						},
+
+						&auth.GroupToOrgRole{
+							GroupDN:        "admin-group",
+							OrgID:          1,
+							IsGrafanaAdmin: newTrue(),
+							OrgRole:        "Admin",
+						},
+					},
+				},
+			},
+		}
+
+		orgMap := createOrganizationMapping(&authConfig)
+		for _, authMap := range authConfig.AuthMappings {
+			for _, group := range authMap.Groups {
+
+				Convey(fmt.Sprintf("Groups %s exists in the OrgMap", group.GroupDN), func() {
+					grpArray, exists := orgMap[group.GroupDN]
+					So(exists, ShouldEqual, true)
+					for _, grp := range grpArray {
+						So(grp.OrgID, ShouldEqual, 1)
+						So(grp.GrafanaAdmin, ShouldEqual, group.IsGrafanaAdmin)
+						So(grp.Role, ShouldEqual, group.OrgRole)
+					}
+				})
+			}
+		}
+
+	})
+
+}

--- a/pkg/services/auth/settings.go
+++ b/pkg/services/auth/settings.go
@@ -12,17 +12,17 @@ import (
 	"github.com/grafana/grafana/pkg/util/errutil"
 )
 
-// AuthConfig holds list of connections to LDAP
+// AuthConfig holds a list of Org Group Mappings
 type AuthConfig struct {
 	AuthMappings []*AuthOrgConfig `toml:"auth"`
 }
 
-// AuthOrgConfig holds connection data to LDAP
+// AuthOrgConfig Lists Groups and Roles per Organization
 type AuthOrgConfig struct {
 	Groups []*GroupToOrgRole `toml:"group_mappings"`
 }
 
-// GroupToOrgRole is a struct representation of LDAP
+// GroupToOrgRole is a struct representation of
 // config "group_mappings" setting
 type GroupToOrgRole struct {
 	GroupDN string `toml:"group_dn"`
@@ -34,16 +34,14 @@ type GroupToOrgRole struct {
 	OrgRole string `toml:"org_role"`
 }
 
-// logger for all LDAP stuff
+// logger
 var logger = log.New("auth.settings")
 
 // loadingMutex locks the reading of the config so multiple requests for reloading are sequential.
 var loadingMutex = &sync.Mutex{}
 
-// IsEnabled checks if ldap is enabled
 func IsEnabled() bool {
 	return true // TODO revisit if oauth has a setting
-	//return setting.LDAPEnabled
 }
 
 // ReloadConfig reads the config from the disc and caches it.
@@ -64,8 +62,7 @@ func ReloadConfig(configFile string) error {
 // could be defined as singleton
 var config *AuthConfig
 
-// GetConfig returns the LDAP config if LDAP is enabled otherwise it returns nil. It returns either cached value of
-// the config or it reads it and caches it first.
+// GetConfig returns the OAuth Mapping config
 func GetConfig(configFile string) (*AuthConfig, error) {
 	if !IsEnabled() {
 		return nil, nil
@@ -88,11 +85,11 @@ func GetConfig(configFile string) (*AuthConfig, error) {
 func readConfig(configFile string) (*AuthConfig, error) {
 	result := &AuthConfig{}
 
-	logger.Info("LDAP enabled, reading config file", "file", configFile)
+	logger.Info("OAuth enabled, reading config file", "file", configFile)
 
 	fileBytes, err := ioutil.ReadFile(configFile)
 	if err != nil {
-		return nil, errutil.Wrap("Failed to load LDAP config file", err)
+		return nil, errutil.Wrap("Failed to load OAuth config file", err)
 	}
 
 	// interpolate full toml string (it can contain ENV variables)
@@ -100,11 +97,11 @@ func readConfig(configFile string) (*AuthConfig, error) {
 
 	_, err = toml.Decode(stringContent, result)
 	if err != nil {
-		return nil, errutil.Wrap("Failed to load LDAP config file", err)
+		return nil, errutil.Wrap("Failed to load OAuth config file", err)
 	}
 
 	if len(result.AuthMappings) == 0 {
-		return nil, xerrors.New("LDAP enabled but no LDAP servers defined in config file")
+		return nil, xerrors.New("OAuth enabled but no mapping defined in config file")
 	}
 
 	// set default org id

--- a/pkg/services/auth/settings.go
+++ b/pkg/services/auth/settings.go
@@ -1,0 +1,121 @@
+package auth
+
+import (
+	"io/ioutil"
+	"sync"
+
+	"github.com/BurntSushi/toml"
+	"golang.org/x/xerrors"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/util/errutil"
+)
+
+// AuthConfig holds list of connections to LDAP
+type AuthConfig struct {
+	AuthMappings []*AuthOrgConfig `toml:"auth"`
+}
+
+// AuthOrgConfig holds connection data to LDAP
+type AuthOrgConfig struct {
+	Groups []*GroupToOrgRole `toml:"group_mappings"`
+}
+
+// GroupToOrgRole is a struct representation of LDAP
+// config "group_mappings" setting
+type GroupToOrgRole struct {
+	GroupDN string `toml:"group_dn"`
+	OrgID   int64  `toml:"org_id"`
+
+	// This pointer specifies if setting was set (for backwards compatibility)
+	IsGrafanaAdmin *bool `toml:"grafana_admin"`
+
+	OrgRole string `toml:"org_role"`
+}
+
+// logger for all LDAP stuff
+var logger = log.New("auth.settings")
+
+// loadingMutex locks the reading of the config so multiple requests for reloading are sequential.
+var loadingMutex = &sync.Mutex{}
+
+// IsEnabled checks if ldap is enabled
+func IsEnabled() bool {
+	return true // TODO revisit if oauth has a setting
+	//return setting.LDAPEnabled
+}
+
+// ReloadConfig reads the config from the disc and caches it.
+func ReloadConfig(configFile string) error {
+	if !IsEnabled() {
+		return nil
+	}
+
+	loadingMutex.Lock()
+	defer loadingMutex.Unlock()
+
+	var err error
+	config, err = readConfig(configFile)
+	return err
+}
+
+// We need to define in this space so `GetConfig` fn
+// could be defined as singleton
+var config *AuthConfig
+
+// GetConfig returns the LDAP config if LDAP is enabled otherwise it returns nil. It returns either cached value of
+// the config or it reads it and caches it first.
+func GetConfig(configFile string) (*AuthConfig, error) {
+	if !IsEnabled() {
+		return nil, nil
+	}
+
+	// Make it a singleton
+	if config != nil {
+		return config, nil
+	}
+
+	loadingMutex.Lock()
+	defer loadingMutex.Unlock()
+
+	var err error
+	config, err = readConfig(configFile)
+
+	return config, err
+}
+
+func readConfig(configFile string) (*AuthConfig, error) {
+	result := &AuthConfig{}
+
+	logger.Info("LDAP enabled, reading config file", "file", configFile)
+
+	fileBytes, err := ioutil.ReadFile(configFile)
+	if err != nil {
+		return nil, errutil.Wrap("Failed to load LDAP config file", err)
+	}
+
+	// interpolate full toml string (it can contain ENV variables)
+	stringContent := setting.EvalEnvVarExpression(string(fileBytes))
+
+	_, err = toml.Decode(stringContent, result)
+	if err != nil {
+		return nil, errutil.Wrap("Failed to load LDAP config file", err)
+	}
+
+	if len(result.AuthMappings) == 0 {
+		return nil, xerrors.New("LDAP enabled but no LDAP servers defined in config file")
+	}
+
+	// set default org id
+	for _, auth := range result.AuthMappings {
+
+		for _, groupMap := range auth.Groups {
+			if groupMap.OrgID == 0 {
+				groupMap.OrgID = 1
+			}
+		}
+	}
+
+	return result, nil
+}

--- a/pkg/setting/setting_oauth.go
+++ b/pkg/setting/setting_oauth.go
@@ -1,9 +1,5 @@
 package setting
 
-type OAuthOrgInfo struct {
-	Role  string
-	OrgId int64
-}
 
 type OAuthInfo struct {
 	ClientId, ClientSecret       string

--- a/pkg/setting/setting_oauth.go
+++ b/pkg/setting/setting_oauth.go
@@ -1,6 +1,5 @@
 package setting
 
-
 type OAuthInfo struct {
 	ClientId, ClientSecret       string
 	Scopes                       []string

--- a/pkg/setting/setting_oauth.go
+++ b/pkg/setting/setting_oauth.go
@@ -1,5 +1,10 @@
 package setting
 
+type OAuthOrgInfo struct {
+	Role  string
+	OrgId int64
+}
+
 type OAuthInfo struct {
 	ClientId, ClientSecret       string
 	Scopes                       []string
@@ -18,6 +23,7 @@ type OAuthInfo struct {
 	TlsClientCa                  string
 	TlsSkipVerify                bool
 	SendClientCredentialsViaPost bool
+	ConfigFile                   string
 }
 
 type OAuther struct {


### PR DESCRIPTION
- Includes Group to Org mappings in a similar style as LDAP
- Reads from a custom authorization toml file which is configurable.