### PR TITLE
Keep higher level roles assigned to a user.

### DIFF
--- a/pkg/api/login_oauth.go
+++ b/pkg/api/login_oauth.go
@@ -207,7 +207,7 @@ func (hs *HTTPServer) OAuthLogin(ctx *m.ReqContext) {
 					org.OrgID = 1
 				}
 
-				// If the incoming role is less than ( less privilage ) than the currently assigned role ( more privilage ), skip this mapping.
+				// If the incoming role is less than ( less privilege ) than the currently assigned role ( more privilege ), skip this mapping.
 				if extUser.OrgRoles[org.OrgID] != "" && roleHierarchy[m.RoleType(org.Role)] < roleHierarchy[extUser.OrgRoles[org.OrgID]] {
 					continue
 				}

--- a/pkg/api/login_oauth.go
+++ b/pkg/api/login_oauth.go
@@ -199,6 +199,12 @@ func (hs *HTTPServer) OAuthLogin(ctx *m.ReqContext) {
 				if org.OrgID == 0 {
 					org.OrgID = 1
 				}
+
+        // Keep the higher Roles assigned to this User/Org combination.
+				if extUser.OrgRoles[org.OrgID] != "" && org.Role == "Viewer" {
+					continue
+				}
+
 				extUser.OrgRoles[org.OrgID] = m.RoleType(org.Role)
 
 				if org.GrafanaAdmin != nil && *org.GrafanaAdmin == true {

--- a/pkg/api/login_oauth.go
+++ b/pkg/api/login_oauth.go
@@ -252,12 +252,12 @@ func (hs *HTTPServer) OAuthLogin(ctx *m.ReqContext) {
 func isRoleAssignable(currentRole m.RoleType, incomingRole m.RoleType) bool {
 	// role hierarchy
 	roleHierarchy := map[m.RoleType]int{
-		m.RoleType("Viewer"): 0,
-		m.RoleType("Editor"): 1,
-		m.RoleType("Admin"):  2,
+		m.ROLE_VIEWER: 0,
+		m.ROLE_EDITOR: 1,
+		m.ROLE_ADMIN:  2,
 	}
 
-	// If the incoming role is less than ( less privilage ) than the currently assigned role ( more privilage ), skip this mapping.
+	// If the incoming role is less than ( less privilege ) than the currently assigned role ( more privilege ), skip this mapping.
 	if currentRole != "" && roleHierarchy[m.RoleType(incomingRole)] < roleHierarchy[currentRole] {
 		return false
 	}

--- a/pkg/api/login_oauth_test.go
+++ b/pkg/api/login_oauth_test.go
@@ -8,18 +8,17 @@ import (
 )
 
 func TestIsRoleAssignable(t *testing.T) {
-
-	viewer := m.RoleType("Viewer")
-	editor := m.RoleType("Editor")
-	admin := m.RoleType("Admin")
-
 	// table test to  validate isRoleAssignable(currentRole, incomingRole)
-	assert.True(t, isRoleAssignable("", viewer))
-	assert.True(t, isRoleAssignable(viewer, editor))
-	assert.True(t, isRoleAssignable(viewer, admin))
-	assert.True(t, isRoleAssignable(editor, admin))
-	assert.False(t, isRoleAssignable(admin, editor))
-	assert.False(t, isRoleAssignable(admin, viewer))
-	assert.False(t, isRoleAssignable(editor, viewer))
-	assert.True(t, isRoleAssignable(viewer, viewer))
+	assert.True(t, isRoleAssignable("", m.ROLE_VIEWER))
+	assert.True(t, isRoleAssignable(m.ROLE_VIEWER, m.ROLE_EDITOR))
+	assert.True(t, isRoleAssignable(m.ROLE_VIEWER, m.ROLE_ADMIN))
+	assert.True(t, isRoleAssignable(m.ROLE_EDITOR, m.ROLE_ADMIN))
+	assert.False(t, isRoleAssignable(m.ROLE_ADMIN, m.ROLE_EDITOR))
+	assert.False(t, isRoleAssignable(m.ROLE_ADMIN, m.ROLE_VIEWER))
+	assert.False(t, isRoleAssignable(m.ROLE_EDITOR, m.ROLE_VIEWER))
+	assert.True(t, isRoleAssignable(m.ROLE_VIEWER, m.ROLE_VIEWER))
+
+	roles := map[int64]m.RoleType{}
+	assert.True(t, isRoleAssignable(roles[0], m.ROLE_VIEWER))
+
 }

--- a/pkg/api/login_oauth_test.go
+++ b/pkg/api/login_oauth_test.go
@@ -1,0 +1,25 @@
+package api
+
+import (
+	"testing"
+
+	m "github.com/grafana/grafana/pkg/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsRoleAssignable(t *testing.T) {
+
+	viewer := m.RoleType("Viewer")
+	editor := m.RoleType("Editor")
+	admin := m.RoleType("Admin")
+
+	// table test to  validate isRoleAssignable(currentRole, incomingRole)
+	assert.True(t, isRoleAssignable("", viewer))
+	assert.True(t, isRoleAssignable(viewer, editor))
+	assert.True(t, isRoleAssignable(viewer, admin))
+	assert.True(t, isRoleAssignable(editor, admin))
+	assert.False(t, isRoleAssignable(admin, editor))
+	assert.False(t, isRoleAssignable(admin, viewer))
+	assert.False(t, isRoleAssignable(editor, viewer))
+	assert.True(t, isRoleAssignable(viewer, viewer))
+}


### PR DESCRIPTION
OIDC and LDAP are ordering groups differently.  This causes in certain situations a user to have downgraded permissions. 

A role hierarchy is created and a check is performed to compare the a new role type to an existing assigned role for a user in an organization.  If the new role has less privileges than the one currently assigned, it is skipped.   These checks happen on login, within the current session. 

For example,

Let's say a users idtoken contained the following groups claim:  

`idtoken - [ eng, everyone, db ] (in this order)`

The oauth.toml configuration would look something like:

```
[[auth.group_mappings]]
org_id = 2
role = Admin
group_dn = eng

[[auth.group_mapping]]
org_id = 2
role = Viewer
group_dn = everyone
```

The loop iterates by the claims in the idtoken. 

Iteration 1:
   Group: `eng`, OrgId `2`, Role: `Admin` .  OK

Iteration 2:
    Group:  `everyone`, OrgId `2`, Role: `Viewer`.  FAILED, user should be an Admin and is now a Viewer.

In some cases the groups in the idtoken the order looks like this:

`idtoken - [ everyone, eng, db] `

In this case, the least permissive role is assigned first, and then overwritten in the next iteration.